### PR TITLE
Removing link to hijacked page

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -91,9 +91,6 @@
                     </li>
                     <li>
                         <a href="https://www.dfri.se/projekt/at4am/">DFRI's project page about AT4AM.eu</a> <small>— support us!</small>
-                    </li>
-                    <li>
-                        <a href="http://at4am.org/">AT4AM for All</a> <small>— the <abbr title="European Parliament">EP</abbr>'s official open source version of AT4AM.</small>
                     </li><!--
             <li>
                 <a href=""></a>


### PR DESCRIPTION
It seems like at4am.org has fallen to some scammers.